### PR TITLE
Fix typo in README that links to build-parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Reproducible Builds Gradle plugin
 
 [![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fgradlex-org%2Freproducible-builds%2Fbadge%3Fref%3Dmain&style=flat)](https://actions-badge.atrox.dev/gradlex-org/build-parameters/goto?ref=main)
-[![Gradle Plugin Portal](https://img.shields.io/maven-metadata/v?label=Plugin%20Portal&metadataUrl=https%3A%2F%2Fplugins.gradle.org%2Fm2%2Forg%2Fgradlex%2Freproducible-builds%2Forg.gradlex.reproducible-builds.gradle.plugin%2Fmaven-metadata.xml)](https://plugins.gradle.org/plugin/org.gradlex.build-parameters)
+[![Gradle Plugin Portal](https://img.shields.io/maven-metadata/v?label=Plugin%20Portal&metadataUrl=https%3A%2F%2Fplugins.gradle.org%2Fm2%2Forg%2Fgradlex%2Freproducible-builds%2Forg.gradlex.reproducible-builds.gradle.plugin%2Fmaven-metadata.xml)](https://plugins.gradle.org/plugin/org.gradlex.reproducible-builds)
 
 Reproducibility settings applied to some of Gradle's built-in tasks, that should really be the default.
 Compatible with Java 8 and Gradle 8.3 or later.


### PR DESCRIPTION
The Plugin Portal badge in the README correctly gets the latest `org.gradlex.reproducible-builds` from the plugin portal, but clicking on the badge directs one to the `org.gradlex.build-parameters` plugin on the Plugin Portal