### PR TITLE
Only change file permission to default if no permission is configured

### DIFF
--- a/src/main/java/org/gradlex/reproduciblebuilds/ReproducibleBuildsPlugin.java
+++ b/src/main/java/org/gradlex/reproduciblebuilds/ReproducibleBuildsPlugin.java
@@ -26,6 +26,8 @@ import org.gradle.api.tasks.scala.ScalaCompile;
 
 import java.nio.charset.StandardCharsets;
 
+import static java.lang.Integer.toOctalString;
+
 @NonNullApi
 public abstract class ReproducibleBuildsPlugin implements Plugin<Project> {
 
@@ -35,7 +37,11 @@ public abstract class ReproducibleBuildsPlugin implements Plugin<Project> {
             task.setPreserveFileTimestamps(false);
             task.setReproducibleFileOrder(true);
             task.dirPermissions(p -> p.unix("755"));
-            task.filePermissions(p -> p.unix("644"));
+            task.eachFile(file -> {
+                if (toOctalString(file.getPermissions().toUnixNumeric()).equals("644")) {
+                    file.permissions(p -> p.unix("644"));
+                }
+            });
         });
 
         project.getTasks().withType(JavaCompile.class).configureEach(task -> {


### PR DESCRIPTION
Working theory:
The [documentation of FilePermissions](https://github.com/gradle/gradle/blob/master/subprojects/core-api/src/main/java/org/gradle/api/file/FilePermissions.java#L31-L39) states:

```
The default permissions used differ between files and directories and are as follows:
[...] FILE: [...] (0644, rw-r--r--)
```

It's not very clear what that means, but it may mean that if you query for the permissions of a file, but no permission was configured, you get this default.

We could use that to check if a permission was potentially not set and only set it then. This will either:
- Override an permission explicitly set to `644` with the same value (no-op)
- Set the `644` for a undefined permission (this is what we want for reproducibility)

```
if (file.getPermissions().toString().equals("644")) {
  file.permissions(p -> p.unix("644"));
}
```

For files that were alreay configured explicitly, for example by the `application` plugin, we will do nothing.
This would fix #7.
 